### PR TITLE
initialize CStream after reset

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -70,6 +70,11 @@ function TranscodingStreams.startproc(codec::ZstdCompressor, mode::Symbol, error
         error[] = ErrorException("zstd error")
         return :error
     end
+    code = initialize!(codec.cstream, codec.level)
+    if iserror(code)
+        error[] = ErrorException("zstd error")
+        return :error
+    end
     return :ok
 end
 


### PR DESCRIPTION
Otherwise setting compress level has no effect.

Sorry for bringing this up again. But this time I have a MWE showcasing the problem.
```julia
using TranscodingStreams
using CodecZstd

function report_ratio(T, lvl)
    text = """
From fairest creatures we desire increase,
That thereby beauty's rose might never die,
But as the riper should by time decease,
His tender heir might bear his memory:
But thou contracted to thine own bright eyes,
Feed'st thy light's flame with self-substantial fuel,
Making a famine where abundance lies,
Thy self thy foe, to thy sweet self too cruel:
Thou that art now the world's fresh ornament,
And only herald to the gaudy spring,
Within thine own bud buriest thy content,
And tender churl mak'st waste in niggarding:
Pity the world, or else this glutton be,
To eat the world's due, by the grave and thee.
"""
    buf = IOBuffer()
    ostream = T(buf; level=lvl)
    write(ostream, text, TranscodingStreams.TOKEN_END)
    flush(ostream)
    compressed = take!(buf)
    close(ostream)
    @info sizeof(compressed) /  sizeof(text)
    return compressed
end
for i = 1:19
    report_ratio(ZstdCompressorStream, i)
    # report_ratio(ZlibCompressorStream, i)
end
```

With this PR, this prints:
```julia
[ Info: 0.6163934426229508
[ Info: 0.6163934426229508
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6131147540983607
[ Info: 0.6131147540983607
[ Info: 0.6131147540983607
[ Info: 0.6131147540983607
[ Info: 0.6131147540983607
[ Info: 0.6131147540983607
[ Info: 0.6131147540983607
[ Info: 0.6131147540983607
[ Info: 0.6131147540983607
[ Info: 0.6114754098360655
[ Info: 0.6114754098360655
[ Info: 0.6163934426229508
[ Info: 0.6131147540983607
```

Otherwise, changing compressing level has no effect.
```
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
[ Info: 0.6147540983606558
```

The differences can actually be quite large if you test with larger, real data.

I guess that `resetCStream` somehow restores the default compressor parameters.