### PR TITLE
Add ZstdFrameCompressor and ZstdFrameDecompressor for non-streaming API

### DIFF
--- a/src/CodecZstd.jl
+++ b/src/CodecZstd.jl
@@ -4,7 +4,10 @@ export
     ZstdCompressor,
     ZstdCompressorStream,
     ZstdDecompressor,
-    ZstdDecompressorStream
+    ZstdDecompressorStream,
+    ZstdFrameCompressor,
+    ZstdFrameDecompressor,
+    ZstdError
 
 import TranscodingStreams:
     TranscodingStreams,
@@ -23,5 +26,7 @@ include("LibZstd_clang.jl")
 include("libzstd.jl")
 include("compression.jl")
 include("decompression.jl")
+include("frameCompression.jl")
+include("frameDecompression.jl")
 
 end # module

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -11,20 +11,21 @@ function Base.show(io::IO, codec::ZstdCompressor)
 end
 
 # Same as the zstd command line tool (v1.2.0).
-const DEFAULT_COMPRESSION_LEVEL = 3
+const DEFAULT_COMPRESSION_LEVEL = DEFAULT_CLEVEL
 
 """
     ZstdCompressor(;level=$(DEFAULT_COMPRESSION_LEVEL))
 
-Create a new zstd compression codec.
+Create a new zstd compression codec using the streaming API.
+This compressor uses `ZSTD_compressStream`.
 
 Arguments
 ---------
-- `level`: compression level (1..$(MAX_CLEVEL))
+- `level`: compression level ($(MIN_CLEVEL)..$(MAX_CLEVEL))
 """
 function ZstdCompressor(;level::Integer=DEFAULT_COMPRESSION_LEVEL)
-    if !(1 ≤ level ≤ MAX_CLEVEL)
-        throw(ArgumentError("level must be within 1..$(MAX_CLEVEL)"))
+    if !(MIN_CLEVEL ≤ level ≤ MAX_CLEVEL)
+        throw(ArgumentError("level must be within $(MIN_CLEVEL)..$(MAX_CLEVEL)"))
     end
     return ZstdCompressor(CStream(), level)
 end

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -12,7 +12,8 @@ end
 """
     ZstdDecompressor()
 
-Create a new zstd decompression codec.
+Create a new zstd decompression codec using the streaming API.
+This decompressor uses `ZSTD_decompressStream`.
 """
 function ZstdDecompressor()
     return ZstdDecompressor(DStream())

--- a/src/frameCompression.jl
+++ b/src/frameCompression.jl
@@ -1,0 +1,101 @@
+# Frame Compressor Codec
+# ======================
+
+struct ZstdFrameCompressor <: TranscodingStreams.Codec
+    cstream::CStream
+    level::Int
+end
+
+function Base.show(io::IO, codec::ZstdFrameCompressor)
+    print(io, summary(codec), "(level=$(codec.level))")
+end
+
+# See compressor.jl for DEFAULT_COMPRESSION_LEVEL
+
+"""
+    ZstdFrameCompressor(;level=$(DEFAULT_COMPRESSION_LEVEL))
+
+Create a new zstd compression codec using the non-streaming API.
+This is uses `ZSTD_compress2`. This compressor expects to have the
+entire input buffer to be compressed available and stores the
+decompressed length in the frame header.
+
+Arguments
+---------
+- `level`: compression level ($(MIN_CLEVEL)..$(MAX_CLEVEL))
+"""
+function ZstdFrameCompressor(;level::Integer=DEFAULT_COMPRESSION_LEVEL)
+    if !(MIN_CLEVEL ≤ level ≤ MAX_CLEVEL)
+        throw(ArgumentError("level must be within $(MIN_CLEVEL)..$(MAX_CLEVEL)"))
+    end
+    return ZstdFrameCompressor(CStream(), level)
+end
+
+const ZstdFrameCompressorStream{S} = TranscodingStream{ZstdFrameCompressor,S} where S<:IO
+
+"""
+    ZstdFrameCompressorStream(stream::IO; kwargs...)
+
+Create a new zstd compression stream (see `ZstdFrameCompressor` for `kwargs`).
+"""
+function ZstdFrameCompressorStream(stream::IO; kwargs...)
+    x, y = splitkwargs(kwargs, (:level,))
+    return TranscodingStream(ZstdFrameCompressor(;x...), stream; y...)
+end
+
+
+# Methods
+# -------
+
+function TranscodingStreams.initialize(codec::ZstdFrameCompressor)
+    code = initialize!(codec.cstream, codec.level)
+    if iserror(code)
+        throw(ZstdError(code))
+    end
+    return
+end
+
+function TranscodingStreams.finalize(codec::ZstdFrameCompressor)
+    if codec.cstream.ptr != C_NULL
+        code = free!(codec.cstream)
+        if iserror(code)
+            throw(ZstdError(code))
+        end
+        codec.cstream.ptr = C_NULL
+    end
+    return
+end
+
+function TranscodingStreams.expectedsize(codec::ZstdFrameCompressor, input::Memory)
+    code = compressed_size_bound(input.size)
+    if iserror(code)
+        throw(ZstdError(code))
+    end
+    return Int(code)
+end
+
+function TranscodingStreams.startproc(codec::ZstdFrameCompressor, mode::Symbol, error::Error)
+    code = reset!(codec.cstream, 0 #=unknown source size=#)
+    if iserror(code)
+        error[] = ZstdError(code)
+        return :error
+    end
+    return :ok
+end
+
+function TranscodingStreams.process(codec::ZstdFrameCompressor, input::Memory, output::Memory, error::Error)
+    cstream = codec.cstream
+    cstream.ibuffer.src = input.ptr
+    cstream.ibuffer.size = input.size
+    cstream.ibuffer.pos = 0
+    cstream.obuffer.dst = output.ptr
+    cstream.obuffer.size = output.size
+    cstream.obuffer.pos = 0
+    code = frameCompress!(cstream)
+    if iserror(code)
+        error[] = ZstdError(code)
+        return 0, 0, :error
+    else
+        return Int(input.size), Int(code), :end
+    end
+end

--- a/src/frameDecompression.jl
+++ b/src/frameDecompression.jl
@@ -1,0 +1,92 @@
+# Decompressor Codec
+# ==================
+
+struct ZstdFrameDecompressor <: TranscodingStreams.Codec
+    dstream::DStream
+end
+
+function Base.show(io::IO, codec::ZstdFrameDecompressor)
+    print(io, summary(codec), "()")
+end
+
+"""
+    ZstdFrameDecompressor()
+
+Create a new zstd decompression codec.
+This decompressor uses the non-streaming API, expecting a known length, via `ZSTD_decompressDCtx`
+"""
+function ZstdFrameDecompressor()
+    return ZstdFrameDecompressor(DStream())
+end
+
+const ZstdFrameDecompressorStream{S} = TranscodingStream{ZstdFrameDecompressor,S} where S<:IO
+
+"""
+    ZstdFrameDecompressorStream(stream::IO; kwargs...)
+
+Create a new zstd decompression stream (`kwargs` are passed to `TranscodingStream`).
+"""
+function ZstdFrameDecompressorStream(stream::IO; kwargs...)
+    return TranscodingStream(ZstdFrameDecompressor(), stream; kwargs...)
+end
+
+
+# Methods
+# -------
+
+function TranscodingStreams.initialize(codec::ZstdFrameDecompressor)
+    code = initialize!(codec.dstream)
+    if iserror(code)
+        throw(ZstdError(code))
+    end
+    return
+end
+
+function TranscodingStreams.finalize(codec::ZstdFrameDecompressor)
+    if codec.dstream.ptr != C_NULL
+        code = free!(codec.dstream)
+        if iserror(code)
+            throw(ZstdError(code))
+        end
+        codec.dstream.ptr = C_NULL
+    end
+    return
+end
+
+function TranscodingStreams.startproc(codec::ZstdFrameDecompressor, mode::Symbol, error::Error)
+    code = reset!(codec.dstream)
+    if iserror(code)
+        error[] = ZstdError(code)
+        return :error
+    end
+    return :ok
+end
+
+function TranscodingStreams.process(codec::ZstdFrameDecompressor, input::Memory, output::Memory, error::Error)
+    dstream = codec.dstream
+    dstream.ibuffer.src = input.ptr
+    dstream.ibuffer.size = input.size
+    dstream.ibuffer.pos = 0
+    dstream.obuffer.dst = output.ptr
+    dstream.obuffer.size = output.size
+    dstream.obuffer.pos = 0
+    code = frameDecompress!(dstream)
+    if iserror(code)
+        error[] = ZstdError(code)
+        return 0, 0, :error
+    else
+        return Int(input.size), Int(code), :end
+    end
+end
+
+function TranscodingStreams.expectedsize(codec::ZstdFrameDecompressor, input::Memory)
+    ret = find_decompressed_size(input.ptr, input.size)
+    if ret == ZSTD_CONTENTSIZE_ERROR
+        throw(ZstdError())
+    elseif ret == ZSTD_CONTENTSIZE_UNKNOWN
+        return Int(decompressed_size_bound(input.ptr, input.size))
+    else
+        # exact size
+        return Int(ret)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,5 +43,9 @@ using Test
     TranscodingStreams.test_roundtrip_transcode(ZstdFrameCompressor, ZstdFrameDecompressor)
     TranscodingStreams.test_roundtrip_transcode(ZstdCompressor, ZstdFrameDecompressor)
 
-    @test_throws "ZstdError: Destination buffer is too small" throw(ZstdError(0xffffffffffffffba))
+    @static if VERSION ≥ v"1.8"
+        @test_throws "ZstdError: Destination buffer is too small" throw(ZstdError(0xffffffffffffffba))
+    else
+        @test_throws ZstdError throw(ZstdError(0xffffffffffffffba))
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,18 @@ using Test
     @test CodecZstd.initialize(codec) === nothing
     @test CodecZstd.finalize(codec) === nothing
 
+    codec = ZstdFrameCompressor()
+    @test codec isa ZstdFrameCompressor
+    @test occursin(r"^ZstdFrameCompressor\(level=\d+\)$", sprint(show, codec))
+    @test CodecZstd.initialize(codec) === nothing
+    @test CodecZstd.finalize(codec) === nothing
+
+    codec = ZstdFrameDecompressor()
+    @test codec isa ZstdFrameDecompressor
+    @test occursin(r"^ZstdFrameDecompressor\(\)$", sprint(show, codec))
+    @test CodecZstd.initialize(codec) === nothing
+    @test CodecZstd.finalize(codec) === nothing
+
     data = [0x28, 0xb5, 0x2f, 0xfd, 0x04, 0x50, 0x19, 0x00, 0x00, 0x66, 0x6f, 0x6f, 0x3f, 0xba, 0xc4, 0x59]
     @test read(ZstdDecompressorStream(IOBuffer(data))) == b"foo"
     @test read(ZstdDecompressorStream(IOBuffer(vcat(data, data)))) == b"foofoo"
@@ -27,4 +39,9 @@ using Test
     TranscodingStreams.test_roundtrip_write(ZstdCompressorStream, ZstdDecompressorStream)
     TranscodingStreams.test_roundtrip_lines(ZstdCompressorStream, ZstdDecompressorStream)
     TranscodingStreams.test_roundtrip_transcode(ZstdCompressor, ZstdDecompressor)
+    TranscodingStreams.test_roundtrip_transcode(ZstdFrameCompressor, ZstdDecompressor)
+    TranscodingStreams.test_roundtrip_transcode(ZstdFrameCompressor, ZstdFrameDecompressor)
+    TranscodingStreams.test_roundtrip_transcode(ZstdCompressor, ZstdFrameDecompressor)
+
+    @test_throws "ZstdError: Destination buffer is too small" throw(ZstdError(0xffffffffffffffba))
 end


### PR DESCRIPTION
Also add ZstdError exception type for more descriptive errors. ZstdError is only
implemented for the new compressors. They will be applied to the streaming compressors
for a breaking version bump.
