### PR TITLE
Detect truncated frames to avoid infinite loop

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -76,7 +76,14 @@ function TranscodingStreams.process(codec::ZstdDecompressor, input::Memory, outp
         error[] = ErrorException("zstd error")
         return Δin, Δout, :error
     else
-        return Δin, Δout, code == 0 ? :end : :ok
+        if code == 0
+            return Δin, Δout, :end
+        elseif input.size == 0
+            error[] = ErrorException("zstd frame truncated. Expected at least $(code) more bytes")
+            return Δin, Δout, :error
+        else
+            return Δin, Δout, :ok
+        end
     end
 end
 

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -78,7 +78,7 @@ function TranscodingStreams.process(codec::ZstdDecompressor, input::Memory, outp
     else
         if code == 0
             return Δin, Δout, :end
-        elseif input.size == 0
+        elseif input.size == 0 && code > 0
             error[] = ErrorException("zstd frame truncated. Expected at least $(code) more bytes")
             return Δin, Δout, :error
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,13 +24,13 @@ Random.seed!(1234)
 
     @testset "Truncated frames" begin
         # issue #24
-        @test_throws "zstd frame truncated." transcode(ZstdDecompressor, UInt8[])
+        @test_throws ErrorException transcode(ZstdDecompressor, UInt8[])
         for trial in 1:1000
             local uncompressed_data = rand(UInt8, rand(0:100))
             local compressed_data = transcode(ZstdCompressor, uncompressed_data)
             local L = length(compressed_data)
             for n in 0:L-1
-                @test_throws "zstd frame truncated." transcode(ZstdDecompressor, compressed_data[1:n])
+                @test_throws ErrorException transcode(ZstdDecompressor, compressed_data[1:n])
             end
             @test transcode(ZstdDecompressor, compressed_data) == uncompressed_data
         end


### PR DESCRIPTION
Fixes #24

The streaming decompression function will only return zero when a frame is fully decoded and flushed out.
If the return value is not an error it will be less than or equal to the number of bytes left in the frame that haven't been read yet.
If `process` is called with `input.size==0` there is no more data left to decompress.

So if there is no more data left to decompress, but zstd is asking for more data, then the frame is truncated, and error should be returned.
Ref: https://github.com/facebook/zstd/issues/340#issuecomment-245942328  https://github.com/facebook/zstd/issues/1109 https://github.com/facebook/zstd/blob/dev/examples/streaming_decompression.c

