### PR TITLE
Add a property interface to ZstdCompressor, add ZstdError type

### DIFF
--- a/src/LibZstd_clang.jl
+++ b/src/LibZstd_clang.jl
@@ -144,6 +144,7 @@ end
     ZSTD_c_minMatch = 105
     ZSTD_c_targetLength = 106
     ZSTD_c_strategy = 107
+    ZSTD_c_targetCBlockSize = 130
     ZSTD_c_enableLongDistanceMatching = 160
     ZSTD_c_ldmHashLog = 161
     ZSTD_c_ldmMinMatch = 162
@@ -1160,8 +1161,6 @@ const ZSTD_c_forceMaxWindow = ZSTD_c_experimentalParam3
 const ZSTD_c_forceAttachDict = ZSTD_c_experimentalParam4
 
 const ZSTD_c_literalCompressionMode = ZSTD_c_experimentalParam5
-
-const ZSTD_c_targetCBlockSize = ZSTD_c_experimentalParam6
 
 const ZSTD_c_srcSizeHint = ZSTD_c_experimentalParam7
 

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -3,7 +3,40 @@
 
 struct ZstdCompressor <: TranscodingStreams.Codec
     cstream::CStream
-    level::Int
+    function ZstdCompressor(cstream, level)
+        self = new(cstream)
+        setParameter!(self.cstream, :compressionLevel, level)
+        return self
+    end
+end
+
+function Base.propertynames(::Type{ZstdCompressor})
+    (fieldnames(ZstdCompressor)..., :level, keys(_parameters_dict)...)
+end
+Base.propertynames(::ZstdCompressor) = propertynames(ZstdCompressor)
+function Base.getproperty(c::ZstdCompressor, p::Symbol)
+    if p == :level
+        p = :compressionLevel
+    end
+    if p in fieldnames(ZstdCompressor)
+        return getfield(c, p)
+    end
+    if p in keys(_parameters_dict)
+        return getParameter(c.cstream, p)
+    end
+    throw(ArgumentError("ZstdCompressor has no property $p"))
+end
+function Base.setproperty!(c::ZstdCompressor, p::Symbol, v::Integer)
+    if p == :level
+        p = :compressionLevel
+    end
+    if p in fieldnames(ZstdCompressor)
+        return setfield!(c, p, v)
+    end
+    if p in keys(_parameters_dict)
+        return setParameter!(c.cstream, p, v)
+    end
+    throw(ArgumentError("ZstdCompressor has no property $p"))
 end
 
 function Base.show(io::IO, codec::ZstdCompressor)


### PR DESCRIPTION
Allow compression parameters to be set as properties

Redo of #48 from the correct branch
