### PR TITLE
Only reset session on error in process, override transcode with pledge

### DIFF
--- a/src/libzstd.jl
+++ b/src/libzstd.jl
@@ -60,6 +60,12 @@ function initialize!(cstream::CStream, level::Integer)
     return LibZstd.ZSTD_initCStream(cstream, level)
 end
 
+function reset!(cstream::CStream)
+    # Resetting session never fails.
+    # Also this will reset the pledged size
+    return LibZstd.ZSTD_CCtx_reset(cstream, LibZstd.ZSTD_reset_session_only)
+end
+
 function reset!(cstream::CStream, srcsize::Integer)
     # ZSTD_resetCStream is deprecated
     # https://github.com/facebook/zstd/blob/9d2a45a705e22ad4817b41442949cd0f78597154/lib/zstd.h#L2253-L2272

--- a/src/libzstd.jl
+++ b/src/libzstd.jl
@@ -169,6 +169,11 @@ end
 const ZSTD_CONTENTSIZE_UNKNOWN = Culonglong(0) - 1
 const ZSTD_CONTENTSIZE_ERROR   = Culonglong(0) - 2
 
+# ZSTD_findDecompressedSize gets the decompressed size of all available frames
+# Alternatively, consider ZSTD_getFrameContentSize for a single frame
 function find_decompressed_size(src::Ptr, size::Integer)
     return LibZstd.ZSTD_findDecompressedSize(src, size)
+end
+function find_decompressed_size(src::Vector{UInt8})
+    return LibZstd.ZSTD_findDecompressedSize(src, length(src))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ Random.seed!(1234)
             for n in 0:L-1
                 @test_throws ErrorException transcode(ZstdDecompressor, compressed_data[1:n])
             end
+            @test CodecZstd.find_decompressed_size(compressed_data) == length(uncompressed_data)
             @test transcode(ZstdDecompressor, compressed_data) == uncompressed_data
         end
     end


### PR DESCRIPTION
This is another approach to making `transcode` save the frame content size.

Previously via #4, the compression session was reset via `startproc`. The
only reason I can glean to reset the session would be if `process` errored.

Now `startproc` only resets the buffers, but does not reset the stream.
The compression context is only reset if an error occurs during `process`.

After these changes we can now call `ZSTD_CCtx_setPledgedSrcSize` from `transcode`
in order to encode the decompressed size in the frame header.
