### PR TITLE
Add test with `test_roundtrip_seekstart`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,11 @@ Random.seed!(1234)
     TranscodingStreams.test_roundtrip_lines(frame_encoder, ZstdDecompressorStream)
     TranscodingStreams.test_roundtrip_transcode(ZstdFrameCompressor, ZstdDecompressor)
 
+    if isdefined(TranscodingStreams, :test_roundtrip_seekstart)
+        TranscodingStreams.test_roundtrip_seekstart(ZstdCompressorStream, ZstdDecompressorStream)
+        TranscodingStreams.test_roundtrip_seekstart(frame_encoder, ZstdDecompressorStream)
+    end
+
     @testset "ZstdFrameCompressor streaming edge case" begin
         codec = ZstdFrameCompressor()
         TranscodingStreams.initialize(codec)


### PR DESCRIPTION
[`test_roundtrip_seekstart`](https://github.com/JuliaIO/TranscodingStreams.jl/blob/d92fd8b9fb0b9314d82b40a96774f7f745b4dab1/ext/TestExt.jl#L65-L81) adds additional test coverage for resetting the compression session. This may be helpful for additional testing of #58 

Ref https://github.com/JuliaIO/TranscodingStreams.jl/issues/217