### PR TITLE
Bump compat for TranscodingStreams to 0.11, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,14 @@ uuid = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>",
            "JuliaIO Github Organization"]
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 
 [compat]
-TranscodingStreams = "0.9, 0.10"
+TranscodingStreams = "0.9, 0.10, 0.11"
 Zstd_jll = "1.5.5"
 julia = "1.3"
 


### PR DESCRIPTION
This update shouldn't affect the public API of this package. TranscodingStreams release notes: https://github.com/JuliaIO/TranscodingStreams.jl/releases/tag/v0.11.0