### PR TITLE
Replace `ZSTD_findDecompressedSize` with `ZSTD_getFrameContentSize`

### DIFF
--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -92,10 +92,11 @@ function TranscodingStreams.process(codec::ZstdDecompressor, input::Memory, outp
 end
 
 function TranscodingStreams.expectedsize(codec::ZstdDecompressor, input::Memory)
-    ret = find_decompressed_size(input.ptr, input.size)
+    ret = LibZstd.ZSTD_getFrameContentSize(input.ptr, input.size)
     if ret == ZSTD_CONTENTSIZE_ERROR
         # something is bad, but we ignore it here
-        return Int(input.size)
+        # but no reason to allocate a ton of extra space if the data isn't valid zstd
+        return 8
     elseif ret == ZSTD_CONTENTSIZE_UNKNOWN
         # random guess
         return Int(input.size * 2)

--- a/src/libzstd.jl
+++ b/src/libzstd.jl
@@ -162,7 +162,3 @@ end
 
 const ZSTD_CONTENTSIZE_UNKNOWN = Culonglong(0) - 1
 const ZSTD_CONTENTSIZE_ERROR   = Culonglong(0) - 2
-
-function find_decompressed_size(src::Ptr, size::Integer)
-    return LibZstd.ZSTD_findDecompressedSize(src, size)
-end

--- a/test/compress_endOp.jl
+++ b/test/compress_endOp.jl
@@ -14,7 +14,7 @@ using Test
         GC.@preserve data begin
             # default endOp
             @test CodecZstd.compress!(cstream; endOp=:continue) == 0
-            @test CodecZstd.find_decompressed_size(cstream.obuffer.dst, cstream.obuffer.pos) == CodecZstd.ZSTD_CONTENTSIZE_UNKNOWN
+            @test CodecZstd.LibZstd.ZSTD_getFrameContentSize(cstream.obuffer.dst, cstream.obuffer.pos) == CodecZstd.ZSTD_CONTENTSIZE_UNKNOWN
         end
     finally
         Base.Libc.free(cstream.obuffer.dst)
@@ -33,7 +33,7 @@ end
     try
         GC.@preserve data begin
             @test CodecZstd.compress!(cstream; endOp=:flush) == 0
-            @test CodecZstd.find_decompressed_size(cstream.obuffer.dst, cstream.obuffer.pos) == CodecZstd.ZSTD_CONTENTSIZE_UNKNOWN
+            @test CodecZstd.LibZstd.ZSTD_getFrameContentSize(cstream.obuffer.dst, cstream.obuffer.pos) == CodecZstd.ZSTD_CONTENTSIZE_UNKNOWN
         end
     finally
         Base.Libc.free(cstream.obuffer.dst)
@@ -53,7 +53,7 @@ end
         GC.@preserve data begin
             # The frame should contain the decompressed size
             @test CodecZstd.compress!(cstream; endOp=:end) == 0
-            @test CodecZstd.find_decompressed_size(cstream.obuffer.dst, cstream.obuffer.pos) == sizeof(data)
+            @test CodecZstd.LibZstd.ZSTD_getFrameContentSize(cstream.obuffer.dst, cstream.obuffer.pos) == sizeof(data)
         end
     finally
         Base.Libc.free(cstream.obuffer.dst)
@@ -64,7 +64,7 @@ end
     data = rand(1:100, 1024*1024)
     compressed = transcode(ZstdFrameCompressor, copy(reinterpret(UInt8, data)))
     GC.@preserve compressed begin
-        @test CodecZstd.find_decompressed_size(pointer(compressed), sizeof(compressed)) == sizeof(data)
+        @test CodecZstd.LibZstd.ZSTD_getFrameContentSize(pointer(compressed), sizeof(compressed)) == sizeof(data)
     end
     @test reinterpret(Int, transcode(ZstdDecompressor, compressed)) == data
     iob = IOBuffer()


### PR DESCRIPTION
Fixes #50 

@mkitti  Do you know how to remove all the `ZSTDLIB_STATIC_API` functions from `LibZstd_clang.jl`? IIUC Julia is not statically linking zstd, so these functions should not be used if we want to avoid future releases of zstd breaking things. 