### PR TITLE
Add tests for `find_decompressed_size` with skippable frames

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,17 @@ Random.seed!(1234)
         end
     end
 
+    @testset "skippable frames" begin
+        skippable_frame = collect(b"P*M\x18\x04\0\0\0\r\0\0\0")
+        u1 = collect(b"")
+        u2 = collect(b"Hello World!")
+        c1 = transcode(ZstdCompressor, u1)
+        c2 = transcode(ZstdCompressor, u2)
+        @test transcode(ZstdDecompressor, skippable_frame) == UInt8[]
+        @test transcode(ZstdDecompressor, [skippable_frame; c1;]) == u1
+        @test transcode(ZstdDecompressor, [skippable_frame; c2;]) == u2
+    end
+
     @test ZstdCompressorStream <: TranscodingStreams.TranscodingStream
     @test ZstdDecompressorStream <: TranscodingStreams.TranscodingStream
 
@@ -91,9 +102,9 @@ Random.seed!(1234)
     end
 
     @testset "find_decompressed_size" begin
-        codec = ZstdFrameCompressor()
-        buffer1 = transcode(codec, "Hello")
-        buffer2 = transcode(codec, "World!")
+        codec = ZstdFrameCompressor
+        buffer1 = transcode(codec, b"Hello")
+        buffer2 = transcode(codec, b"World!")
         @test CodecZstd.find_decompressed_size(buffer1) == 5
         @test CodecZstd.find_decompressed_size(buffer2) == 6
 
@@ -116,9 +127,9 @@ Random.seed!(1234)
         v = take!(iob)
         @test CodecZstd.find_decompressed_size(v) == 22
 
-        codec = ZstdCompressor()
-        buffer3 = transcode(codec, "Hello")
-        buffer4 = transcode(codec, "World!")
+        codec = ZstdCompressor
+        buffer3 = transcode(codec, b"Hello")
+        buffer4 = transcode(codec, b"World!")
         @test CodecZstd.find_decompressed_size(buffer3) == CodecZstd.ZSTD_CONTENTSIZE_UNKNOWN
         @test CodecZstd.find_decompressed_size(buffer4) == CodecZstd.ZSTD_CONTENTSIZE_UNKNOWN
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,8 @@ using Test
 
 Random.seed!(1234)
 
+include("utils.jl")
+
 @testset "Zstd Codec" begin
     codec = ZstdCompressor()
     @test codec isa ZstdCompressor
@@ -43,7 +45,7 @@ Random.seed!(1234)
     end
 
     @testset "skippable frames" begin
-        skippable_frame = collect(b"P*M\x18\x04\0\0\0\r\0\0\0")
+        skippable_frame = create_skippable_frame(b"\r\0\0\0")
         u1 = collect(b"")
         u2 = collect(b"Hello World!")
         c1 = transcode(ZstdCompressor, u1)

--- a/test/static_only_tests.jl
+++ b/test/static_only_tests.jl
@@ -63,7 +63,7 @@ These tests use the static-only API to test `find_decompressed_size`
     @test CodecZstd.find_decompressed_size(v) == LibZstdStatic.ZSTD_findDecompressedSize(v)
 
     @testset "skippable frames" begin
-        skippable_frame = collect(b"P*M\x18\x04\0\0\0\r\0\0\0")
+        skippable_frame = create_skippable_frame(b"\r\0\0\0")
         @test CodecZstd.find_decompressed_size(skippable_frame) == LibZstdStatic.ZSTD_findDecompressedSize(skippable_frame)
         @test CodecZstd.find_decompressed_size(skippable_frame) == 0
         for d in 0:2

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,13 @@
+"""
+    create_skippable_frame(user_data::AbstractVector{UInt8}, magic_number::UInt32=0x184D2A50)::Vector{UInt8}
+
+Return a skippable frame containing `user_data`.
+"""
+function create_skippable_frame(user_data::AbstractVector{UInt8}, magic_number::UInt32=0x184D2A50)
+    @assert magic_number ∈ 0x184D2A50:0x184D2A5F
+    UInt8[
+        reinterpret(UInt8, [htol(magic_number)]);
+        reinterpret(UInt8, [htol(UInt32(length(user_data)))]);
+        user_data;
+    ]
+end


### PR DESCRIPTION
The implementation of `find_decompressed_size` is missing [the special checks for skippable frames found in `zstd`](https://github.com/facebook/zstd/blob/20707e3718ee14250fb8a44b3bf023ea36bd88df/lib/decompress/zstd_decompress.c#L648-L656 )

This PR adds tests to ensure the current implementation works correctly with skippable frames.

This PR also fixes initialization problems in some of the tests. 
