### PR TITLE
Add additional parameters to ZstdCompressor

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -138,7 +138,7 @@ end
 # -------
 
 function TranscodingStreams.initialize(codec::ZstdCompressor)
-    code = initialize!(codec.cstream, codec.level)
+    code = initialize!(codec.cstream, codec.parameters)
     if iserror(code)
         zstderror(codec.cstream, code)
     end


### PR DESCRIPTION
This draft pull request adds additional parameters for the compressor.
The implementation uses a `Dict{LibZstd.ZSTD_cParameter, Cint}` to store the parameters.
The properties are the overloaded to reflect the parameters.
