### PR TITLE
Auto initialize in `startproc`

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -86,7 +86,7 @@ function TranscodingStreams.finalize(codec::ZstdCompressor)
         end
         codec.cstream.ptr = C_NULL
     end
-    nothing
+    return
 end
 
 function TranscodingStreams.startproc(codec::ZstdCompressor, mode::Symbol, error::Error)

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -98,7 +98,7 @@ function TranscodingStreams.startproc(codec::ZstdCompressor, mode::Symbol, error
         codec.cstream.ptr = ptr
         i_code = initialize!(codec.cstream, codec.level)
         if iserror(i_code)
-            error[] = ErrorException("zstd error")
+            error[] = ErrorException("zstd initialization error")
             return :error
         end
     end

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -91,11 +91,10 @@ end
 
 function TranscodingStreams.startproc(codec::ZstdCompressor, mode::Symbol, error::Error)
     if codec.cstream.ptr == C_NULL
-        ptr = LibZstd.ZSTD_createCStream()
-        if ptr == C_NULL
+        codec.cstream.ptr = LibZstd.ZSTD_createCStream()
+        if codec.cstream.ptr == C_NULL
             throw(OutOfMemoryError())
         end
-        codec.cstream.ptr = ptr
         i_code = initialize!(codec.cstream, codec.level)
         if iserror(i_code)
             error[] = ErrorException("zstd initialization error")

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -41,7 +41,7 @@ function TranscodingStreams.finalize(codec::ZstdDecompressor)
         end
         codec.dstream.ptr = C_NULL
     end
-    nothing
+    return
 end
 
 function TranscodingStreams.startproc(codec::ZstdDecompressor, mode::Symbol, error::Error)

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -33,16 +33,6 @@ end
 # Methods
 # -------
 
-function TranscodingStreams.initialize(codec::ZstdDecompressor)
-    code = initialize!(codec.dstream)
-    if iserror(code)
-        zstderror(codec.dstream, code)
-    end
-    reset!(codec.dstream.ibuffer)
-    reset!(codec.dstream.obuffer)
-    return
-end
-
 function TranscodingStreams.finalize(codec::ZstdDecompressor)
     if codec.dstream.ptr != C_NULL
         code = free!(codec.dstream)
@@ -51,12 +41,22 @@ function TranscodingStreams.finalize(codec::ZstdDecompressor)
         end
         codec.dstream.ptr = C_NULL
     end
-    reset!(codec.dstream.ibuffer)
-    reset!(codec.dstream.obuffer)
-    return
+    nothing
 end
 
 function TranscodingStreams.startproc(codec::ZstdDecompressor, mode::Symbol, error::Error)
+    if codec.dstream.ptr == C_NULL
+        ptr = LibZstd.ZSTD_createDStream()
+        if ptr == C_NULL
+            throw(OutOfMemoryError())
+        end
+        codec.dstream.ptr = ptr
+        i_code = initialize!(codec.dstream)
+        if iserror(i_code)
+            error[] = ErrorException("zstd initialization error")
+            return :error
+        end
+    end
     code = reset!(codec.dstream)
     if iserror(code)
         error[] = ErrorException("zstd error")
@@ -66,6 +66,9 @@ function TranscodingStreams.startproc(codec::ZstdDecompressor, mode::Symbol, err
 end
 
 function TranscodingStreams.process(codec::ZstdDecompressor, input::Memory, output::Memory, error::Error)
+    if codec.dstream.ptr == C_NULL
+        error("startproc must be called before process")
+    end
     dstream = codec.dstream
     dstream.ibuffer.src = input.ptr
     dstream.ibuffer.size = input.size

--- a/src/decompression.jl
+++ b/src/decompression.jl
@@ -46,11 +46,10 @@ end
 
 function TranscodingStreams.startproc(codec::ZstdDecompressor, mode::Symbol, error::Error)
     if codec.dstream.ptr == C_NULL
-        ptr = LibZstd.ZSTD_createDStream()
-        if ptr == C_NULL
+        codec.dstream.ptr = LibZstd.ZSTD_createDStream()
+        if codec.dstream.ptr == C_NULL
             throw(OutOfMemoryError())
         end
-        codec.dstream.ptr = ptr
         i_code = initialize!(codec.dstream)
         if iserror(i_code)
             error[] = ErrorException("zstd initialization error")

--- a/src/libzstd.jl
+++ b/src/libzstd.jl
@@ -123,11 +123,7 @@ mutable struct DStream
     obuffer::OutBuffer
 
     function DStream()
-        ptr = LibZstd.ZSTD_createDStream()
-        if ptr == C_NULL
-            throw(OutOfMemoryError())
-        end
-        return new(ptr, InBuffer(), OutBuffer())
+        return new(C_NULL, InBuffer(), OutBuffer())
     end
 end
 Base.unsafe_convert(::Type{Ptr{LibZstd.ZSTD_DStream}}, dstream::DStream) = dstream.ptr

--- a/src/libzstd.jl
+++ b/src/libzstd.jl
@@ -44,11 +44,7 @@ mutable struct CStream
     obuffer::OutBuffer
 
     function CStream()
-        ptr = LibZstd.ZSTD_createCStream()
-        if ptr == C_NULL
-            throw(OutOfMemoryError())
-        end
-        return new(ptr, InBuffer(), OutBuffer())
+        return new(C_NULL, InBuffer(), OutBuffer())
     end
 end
 

--- a/src/libzstd.jl
+++ b/src/libzstd.jl
@@ -137,6 +137,8 @@ end
 function reset!(dstream::DStream)
     # LibZstd.ZSTD_resetDStream is deprecated
     # https://github.com/facebook/zstd/blob/9d2a45a705e22ad4817b41442949cd0f78597154/lib/zstd.h#L2332-L2339
+    reset!(dstream.ibuffer)
+    reset!(dstream.obuffer)
     return LibZstd.ZSTD_DCtx_reset(dstream, LibZstd.ZSTD_reset_session_only)
 end
 

--- a/test/compress_endOp.jl
+++ b/test/compress_endOp.jl
@@ -4,6 +4,7 @@ using Test
 @testset "compress! endOp = :continue" begin
     data = rand(1:100, 1024*1024)
     cstream = CodecZstd.CStream()
+    cstream.ptr = CodecZstd.LibZstd.ZSTD_createCStream()
     cstream.ibuffer.src = pointer(data)
     cstream.ibuffer.size = sizeof(data)
     cstream.ibuffer.pos = 0
@@ -24,6 +25,7 @@ end
 @testset "compress! endOp = :flush" begin
     data = rand(1:100, 1024*1024)
     cstream = CodecZstd.CStream()
+    cstream.ptr = CodecZstd.LibZstd.ZSTD_createCStream()
     cstream.ibuffer.src = pointer(data)
     cstream.ibuffer.size = sizeof(data)
     cstream.ibuffer.pos = 0
@@ -43,6 +45,7 @@ end
 @testset "compress! endOp = :end" begin
     data = rand(1:100, 1024*1024)
     cstream = CodecZstd.CStream()
+    cstream.ptr = CodecZstd.LibZstd.ZSTD_createCStream()
     cstream.ibuffer.src = pointer(data)
     cstream.ibuffer.size = sizeof(data)
     cstream.ibuffer.pos = 0

--- a/test/compress_endOp.jl
+++ b/test/compress_endOp.jl
@@ -3,22 +3,22 @@ using Test
 
 @testset "compress! endOp = :continue" begin
     data = rand(1:100, 1024*1024)
-    cstream = CodecZstd.CStream()
-    cstream.ptr = CodecZstd.LibZstd.ZSTD_createCStream()
-    cstream.ibuffer.src = pointer(data)
-    cstream.ibuffer.size = sizeof(data)
-    cstream.ibuffer.pos = 0
-    cstream.obuffer.dst = Base.Libc.malloc(sizeof(data)*2)
-    cstream.obuffer.size = sizeof(data)*2
-    cstream.obuffer.pos = 0
-    try
-        GC.@preserve data begin
+    GC.@preserve data begin
+        cstream = CodecZstd.CStream()
+        cstream.ptr = CodecZstd.LibZstd.ZSTD_createCStream()
+        cstream.ibuffer.src = pointer(data)
+        cstream.ibuffer.size = sizeof(data)
+        cstream.ibuffer.pos = 0
+        cstream.obuffer.dst = Base.Libc.malloc(sizeof(data)*2)
+        cstream.obuffer.size = sizeof(data)*2
+        cstream.obuffer.pos = 0
+        try
             # default endOp
             @test CodecZstd.compress!(cstream; endOp=:continue) == 0
             @test CodecZstd.find_decompressed_size(cstream.obuffer.dst, cstream.obuffer.pos) == CodecZstd.ZSTD_CONTENTSIZE_UNKNOWN
+        finally
+            Base.Libc.free(cstream.obuffer.dst)
         end
-    finally
-        Base.Libc.free(cstream.obuffer.dst)
     end
 end
 


### PR DESCRIPTION
Fixes #70.  Third time's the charm

This PR avoids the complexity of interacting with GC in #71 by checking if the context is null when `startproc` is called.
If the context is null `startproc` initializes the context.

This means `finalize` is still needed to prevent memory leaks, but there is no issue of use after free.