### PR TITLE
Improve error handling

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,12 +22,13 @@ jobs:
         version:
           - '1.6'
           - '1'
+          - 'pre'
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
         arch:
-          - x64
+          - 'default'
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -14,9 +14,7 @@ jobs:
       matrix:
         package:
           - "Arrow"
-          - "JLD2"
           - "HDF5"
-          - "Parquet2"
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
 license = "MIT"
 authors = ["Kenta Sato <bicycle1885@gmail.com>",
            "JuliaIO Github Organization"]
-version = "0.8.6"
+version = "0.8.7-dev"
 
 [deps]
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
@@ -12,4 +12,4 @@ Zstd_jll = "3161d3a3-bdf6-5164-811a-617609db77b4"
 [compat]
 TranscodingStreams = "0.9, 0.10, 0.11"
 Zstd_jll = "1.5.5"
-julia = "1.3"
+julia = "1.6"

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -25,13 +25,17 @@ Create a new zstd compression codec.
 
 Arguments
 ---------
-- `level`: compression level (1..$(MAX_CLEVEL))
+- `level`: compression level, regular levels are 1-22.
+
+  Levels ≥ 20 should be used with caution, as they require more memory.
+  The library also offers negative compression levels,
+  which extend the range of speed vs. ratio preferences.
+  The lower the level, the faster the speed (at the cost of compression).
+  0 is a special value for `ZSTD_defaultCLevel()`.
+  The level will be clamped to the range `ZSTD_minCLevel()` to `ZSTD_maxCLevel()`.
 """
 function ZstdCompressor(;level::Integer=DEFAULT_COMPRESSION_LEVEL)
-    if !(1 ≤ level ≤ MAX_CLEVEL)
-        throw(ArgumentError("level must be within 1..$(MAX_CLEVEL)"))
-    end
-    return ZstdCompressor(CStream(), level)
+    ZstdCompressor(CStream(), clamp(level, LibZstd.ZSTD_minCLevel(), LibZstd.ZSTD_maxCLevel()))
 end
 ZstdCompressor(cstream, level) = ZstdCompressor(cstream, level, :continue)
 
@@ -43,13 +47,17 @@ closes the frame, encoding the decompressed size of that frame.
 
 Arguments
 ---------
-- `level`: compression level (1..$(MAX_CLEVEL))
+- `level`: compression level, regular levels are 1-22.
+
+  Levels ≥ 20 should be used with caution, as they require more memory.
+  The library also offers negative compression levels,
+  which extend the range of speed vs. ratio preferences.
+  The lower the level, the faster the speed (at the cost of compression).
+  0 is a special value for `ZSTD_defaultCLevel()`.
+  The level will be clamped to the range `ZSTD_minCLevel()` to `ZSTD_maxCLevel()`.
 """
 function ZstdFrameCompressor(;level::Integer=DEFAULT_COMPRESSION_LEVEL)
-    if !(1 ≤ level ≤ MAX_CLEVEL)
-        throw(ArgumentError("level must be within 1..$(MAX_CLEVEL)"))
-    end
-    return ZstdCompressor(CStream(), level, :end)
+    ZstdCompressor(CStream(), clamp(level, LibZstd.ZSTD_minCLevel(), LibZstd.ZSTD_maxCLevel()), :end)
 end
 # pretend that ZstdFrameCompressor is a compressor type
 function TranscodingStreams.transcode(C::typeof(ZstdFrameCompressor), args...)
@@ -80,36 +88,39 @@ end
 
 function TranscodingStreams.finalize(codec::ZstdCompressor)
     if codec.cstream.ptr != C_NULL
-        code = free!(codec.cstream)
-        if iserror(code)
-            zstderror(codec.cstream, code)
-        end
+        # This should never fail
+        @assert !iserror(free!(codec.cstream))
         codec.cstream.ptr = C_NULL
     end
     return
 end
 
-function TranscodingStreams.startproc(codec::ZstdCompressor, mode::Symbol, error::Error)
+function TranscodingStreams.startproc(codec::ZstdCompressor, mode::Symbol, err::Error)
     if codec.cstream.ptr == C_NULL
-        codec.cstream.ptr = LibZstd.ZSTD_createCStream()
+        # Create the context following the example in:
+        # https://github.com/facebook/zstd/blob/98d2b90e82e5188968368d952ad6b371772e78e5/examples/streaming_compression.c#L36-L44
+        codec.cstream.ptr = LibZstd.ZSTD_createCCtx()
         if codec.cstream.ptr == C_NULL
             throw(OutOfMemoryError())
         end
-        i_code = initialize!(codec.cstream, codec.level)
-        if iserror(i_code)
-            error[] = ErrorException("zstd initialization error")
+        ret = LibZstd.ZSTD_CCtx_setParameter(codec.cstream, LibZstd.ZSTD_c_compressionLevel, clamp(codec.level, Cint))
+        # TODO Allow setting other parameters here.
+        if iserror(ret)
+            # This is unreachable according to zstd.h
+            err[] = ErrorException("zstd initialization error")
             return :error
         end
     end
     code = reset!(codec.cstream, 0 #=unknown source size=#)
     if iserror(code)
-        error[] = ErrorException("zstd error")
+        # This is unreachable according to zstd.h
+        err[] = ErrorException("zstd error resetting context.")
         return :error
     end
     return :ok
 end
 
-function TranscodingStreams.process(codec::ZstdCompressor, input::Memory, output::Memory, error::Error)
+function TranscodingStreams.process(codec::ZstdCompressor, input::Memory, output::Memory, err::Error)
     if codec.cstream.ptr == C_NULL
         error("startproc must be called before process")
     end
@@ -139,15 +150,17 @@ function TranscodingStreams.process(codec::ZstdCompressor, input::Memory, output
     cstream.obuffer.size = output.size
     cstream.obuffer.pos = 0
     if input.size == 0
-        code = finish!(cstream)
+        code = compress!(cstream; endOp = LibZstd.ZSTD_e_end)
     else
         code = compress!(cstream; endOp = codec.endOp)
     end
     Δin = Int(cstream.ibuffer.pos - ibuffer_starting_pos)
     Δout = Int(cstream.obuffer.pos)
     if iserror(code)
-        ptr = LibZstd.ZSTD_getErrorName(code)
-        error[] = ErrorException("zstd error: " * unsafe_string(ptr))
+        if error_code(code) == Integer(LibZstd.ZSTD_error_memory_allocation)
+            throw(OutOfMemoryError())
+        end
+        err[] = ErrorException("zstd compression error: " * error_name(code))
         return Δin, Δout, :error
     else
         return Δin, Δout, input.size == 0 && code == 0 ? :end : :ok


### PR DESCRIPTION
Fixes #80 by improving the error handling.

This PR also updates the min Julia version to 1.6, because this is needed to install Zstd_jll 1.5.5

This PR also removes the errors when constructing the codec by clamping the level parameter to the range supported by whatever version of zstd is being used.