### PR TITLE
Delete broken `ZstdCompressor` constructor

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -93,7 +93,6 @@ function ZstdCompressor(;
         LibZstd.ZSTD_e_continue,
     )
 end
-ZstdCompressor(cstream, level) = ZstdCompressor(cstream, level, Int32(0), :continue)
 
 """
    ZstdFrameCompressor(;level=$(DEFAULT_COMPRESSION_LEVEL))

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -93,7 +93,7 @@ function ZstdCompressor(;
         LibZstd.ZSTD_e_continue,
     )
 end
-ZstdCompressor(cstream, level) = ZstdCompressor(cstream, level, :continue)
+ZstdCompressor(cstream, level) = ZstdCompressor(cstream, level, Int32(0), :continue)
 
 """
    ZstdFrameCompressor(;level=$(DEFAULT_COMPRESSION_LEVEL))


### PR DESCRIPTION
This method of the `ZstdCompressor` constructor is undocumented, untested, and appears not to be used downstream; therefore, this PR removes it.